### PR TITLE
Fixing an "indices must be integers" error

### DIFF
--- a/reference-importer/src/crossref.py
+++ b/reference-importer/src/crossref.py
@@ -57,7 +57,7 @@ def main(wf):
             elif 'short-container-title' in item:
                 journal = item['short-container-title'][0]
             elif 'institution' in item:
-                journal = item['institution']['name']
+                journal = item['institution'][0]
             authors = []
             if 'author' in item:
                 for author in item['author']:


### PR DESCRIPTION
I got an error for some crossref searches. Here's the error message from the Alfred debugger:

```
workflow.py:2080 ERROR    list indices must be integers, not str
Traceback (most recent call last):
  File ".../workflow/workflow.py", line 2073, in run
    func(self)
  File "crossref.py", line 60, in main
    journal = item['institution']['name']
TypeError: list indices must be integers, not str
```

(Note: I removed some details of the file path (where I wrote "...") for workflow.py because they are not important and are specific to my machine.)

There was an easy fix for this: I just changed line 60 in crossref.py (the line called out in the error message above) to the following:

```
                journal = item['institution'][0]
```

Basically, I replaced `'name'` with `0`. So far this seems to work great, with the matches showing paper title, author names and the citation source (i.e., the journal). Hopefully, the edit I made won't cause some other problem down the line.

 On branch dev
 Your branch is up to date with 'origin/dev'.

 Changes to be committed:
	modified:   src/crossref.py